### PR TITLE
Make php-cs-fixer show CS violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpstan/phpstan": "^1.10"
     },
     "scripts": {
-        "cs": "php-cs-fixer fix --allow-risky=yes --dry-run",
+        "cs": "php-cs-fixer fix --allow-risky=yes --dry-run --diff",
         "cs:fix": "php-cs-fixer fix --allow-risky=yes",
         "stan": "phpstan analyse",
         "unit": "phpunit --testsuite=Unit",


### PR DESCRIPTION
Currently we are blind
https://github.com/PrinsFrank/sunsetrise/actions/runs/5615274341/job/15215206293
